### PR TITLE
refactor: Pass payload properties explicitly in `from_api_response` methods

### DIFF
--- a/src/pypilecore/results/grouper_result.py
+++ b/src/pypilecore/results/grouper_result.py
@@ -279,6 +279,7 @@ class SingleClusterResult:
         cls, response_dict: dict, pile_load_uls: float
     ) -> "SingleClusterResult":
         try:
+            table = response_dict["table"]
             return cls(
                 cpt_names=response_dict["names"],
                 coordinates=response_dict["coordinates"],
@@ -292,7 +293,37 @@ class SingleClusterResult:
                 spatial_check=response_dict["spatial_check"],
                 variation_check=response_dict["variation_check"],
                 centre_to_centre_check=response_dict["centre_to_centre_check"],
-                data=SingleClusterData(**response_dict["table"]),
+                data=SingleClusterData(
+                    characteristic_bearing_capacity=table[
+                        "characteristic_bearing_capacity"
+                    ],
+                    design_bearing_capacity=table["design_bearing_capacity"],
+                    design_negative_friction=table["design_negative_friction"],
+                    group_centre_to_centre_validation=table[
+                        "group_centre_to_centre_validation"
+                    ],
+                    group_centre_to_centre_validation_15=table[
+                        "group_centre_to_centre_validation_15"
+                    ],
+                    group_centre_to_centre_validation_20=table[
+                        "group_centre_to_centre_validation_20"
+                    ],
+                    group_centre_to_centre_validation_25=table[
+                        "group_centre_to_centre_validation_25"
+                    ],
+                    mean_calculated_bearing_capacity=table[
+                        "mean_calculated_bearing_capacity"
+                    ],
+                    min_calculated_bearing_capacity=table[
+                        "min_calculated_bearing_capacity"
+                    ],
+                    net_design_bearing_capacity=table["net_design_bearing_capacity"],
+                    nominal_cpt=table["nominal_cpt"],
+                    pile_tip_level=table["pile_tip_level"],
+                    variation_coefficient=table["variation_coefficient"],
+                    xi_factor=table["xi_factor"],
+                    xi_values=table["xi_values"],
+                ),
             )
         except KeyError as e:
             raise KeyError(

--- a/src/pypilecore/results/multi_cpt_results.py
+++ b/src/pypilecore/results/multi_cpt_results.py
@@ -453,13 +453,46 @@ class MultiCPTBearingResults:
         cpt_results_dict = SingleCPTBearingResultsContainer.from_api_response(
             cpt_results_list=response_dict["cpts"], cpt_input=cpt_input
         )
-
+        group_results = response_dict["group_results"]
         return cls(
             cpt_results=cpt_results_dict,
             pile_properties=create_pile_properties_from_api_response(
                 response_dict["pile_properties"]
             ),
-            group_results_table=CPTGroupResultsTable(**response_dict["group_results"]),
+            group_results_table=CPTGroupResultsTable(
+                pile_tip_level_nap=group_results["pile_tip_level_nap"],
+                R_s_k=group_results["R_s_k"],
+                R_b_k=group_results["R_b_k"],
+                R_c_k=group_results["R_c_k"],
+                R_c_d=group_results["R_c_d"],
+                F_nk_cal_mean=group_results["F_nk_cal_mean"],
+                F_nk_k=group_results["F_nk_k"],
+                F_nk_d=group_results["F_nk_d"],
+                R_c_d_net=group_results["R_c_d_net"],
+                F_c_k=group_results["F_c_k"],
+                F_c_k_tot=group_results["F_c_k_tot"],
+                s_b=group_results["s_b"],
+                s_e=group_results["s_e"],
+                s_e_mean=group_results["s_e_mean"],
+                R_b_mob_ratio=group_results["R_b_mob_ratio"],
+                R_s_mob_ratio=group_results["R_s_mob_ratio"],
+                k_v_b=group_results["k_v_b"],
+                k_v_1=group_results["k_v_1"],
+                R_c_min=group_results["R_c_min"],
+                R_c_max=group_results["R_c_max"],
+                R_c_mean=group_results["R_c_mean"],
+                R_c_std=group_results["R_c_std"],
+                R_s_mean=group_results["R_s_mean"],
+                R_b_mean=group_results["R_b_mean"],
+                var_coef=group_results["var_coef"],
+                n_cpts=group_results["n_cpts"],
+                use_group_average=group_results["use_group_average"],
+                xi_normative=group_results["xi_normative"],
+                xi_value=group_results["xi_value"],
+                cpt_Rc_min=group_results["cpt_Rc_min"],
+                cpt_Rc_max=group_results["cpt_Rc_max"],
+                cpt_normative=group_results["cpt_normative"],
+            ),
             gamma_f_nk=response_dict["calculation_params"]["gamma_f_nk"],
             gamma_r_b=response_dict["calculation_params"]["gamma_r_b"],
             gamma_r_s=response_dict["calculation_params"]["gamma_r_s"],

--- a/src/pypilecore/results/single_cpt_results.py
+++ b/src/pypilecore/results/single_cpt_results.py
@@ -241,6 +241,7 @@ class SingleCPTBearingResults:
         x: float | None = None,
         y: float | None = None,
     ) -> "SingleCPTBearingResults":
+        results_table = cpt_results_dict["results_table"]
         return cls(
             soil_properties=SoilProperties(
                 cpt_table=CPTTable.from_api_response(
@@ -256,7 +257,45 @@ class SingleCPTBearingResults:
                 y=y,
             ),
             pile_head_level_nap=cpt_results_dict["annotations"]["pile_head_level_nap"],
-            results_table=CPTResultsTable(**cpt_results_dict["results_table"]),
+            results_table=CPTResultsTable(
+                pile_tip_level_nap=results_table["pile_tip_level_nap"],
+                F_nk_cal=results_table["F_nk_cal"],
+                F_nk_k=results_table["F_nk_k"],
+                F_nk_d=results_table["F_nk_d"],
+                R_b_cal=results_table["R_b_cal"],
+                R_b_k=results_table["R_b_k"],
+                R_b_d=results_table["R_b_d"],
+                R_s_cal=results_table["R_s_cal"],
+                R_s_k=results_table["R_s_k"],
+                R_s_d=results_table["R_s_d"],
+                R_c_cal=results_table["R_c_cal"],
+                R_c_k=results_table["R_c_k"],
+                R_c_d=results_table["R_c_d"],
+                R_c_d_net=results_table["R_c_d_net"],
+                F_c_k=results_table["F_c_k"],
+                F_c_k_tot=results_table["F_c_k_tot"],
+                negative_friction_range_nap_top=results_table[
+                    "negative_friction_range_nap_top"
+                ],
+                negative_friction_range_nap_btm=results_table[
+                    "negative_friction_range_nap_btm"
+                ],
+                positive_friction_range_nap_top=results_table[
+                    "positive_friction_range_nap_top"
+                ],
+                positive_friction_range_nap_btm=results_table[
+                    "positive_friction_range_nap_btm"
+                ],
+                q_b_max=results_table["q_b_max"],
+                q_s_max_mean=results_table["q_s_max_mean"],
+                qc1=results_table["qc1"],
+                qc2=results_table["qc2"],
+                qc3=results_table["qc3"],
+                s_b=results_table["s_b"],
+                s_el=results_table["s_el"],
+                k_v_b=results_table["k_v_b"],
+                k_v_1=results_table["k_v_1"],
+            ),
         )
 
     @property


### PR DESCRIPTION
... instead of dumping the content as keyword arguments