### PR TITLE
fix: Don't filter NaN values in the table result from SingleCPTBearin…

### DIFF
--- a/src/pypilecore/results/multi_cpt_results.py
+++ b/src/pypilecore/results/multi_cpt_results.py
@@ -385,6 +385,7 @@ class SingleCPTBearingResultsContainer:
             values=column_name,
             index="pile_tip_level_nap",
             columns="test_id",
+            dropna=False,
         )
         return results.sort_values("pile_tip_level_nap", ascending=False)
 


### PR DESCRIPTION
…gResultsContainer.get_results_per_cpt()