### PR TITLE
Remove Single;mean;sqrt and Group;normative traces from boxplot()

### DIFF
--- a/notebooks/PileCore_multi_cpt_grouper.ipynb
+++ b/notebooks/PileCore_multi_cpt_grouper.ipynb
@@ -429,7 +429,7 @@
     "\n",
     "# ** gamma_f_nk\n",
     "# Safetyfactor on the negative friction\n",
-    "# Note: Use 1.4 if bottom negative friction ≠ positive friction\n",
+    "# Note: Use 1.4 if bottom negative friction \u2260 positive friction\n",
     "# If None, the default is 1.0\n",
     "gamma_f_nk = 1.0\n",
     "\n",
@@ -698,7 +698,7 @@
     "is_open_ended = None\n",
     "\n",
     "# ** negative_fr_delta_factor\n",
-    "# factor * φ = δ. This parameter will be multiplied with phi to get the delta parameter\n",
+    "# factor * \u03c6 = \u03b4. This parameter will be multiplied with phi to get the delta parameter\n",
     "# used in negative friction calculation according to NEN-9997-1 7.3.2.2 (e). Typically\n",
     "# values are 1.0 for piles cast in place, and 0.75 for other pile types. The value is\n",
     "# inferred from the pile_type_specifications, but can be overwritten.\n",
@@ -901,7 +901,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Download CPT's from BRO: 100%|██████████| 9/9 [00:03<00:00,  2.86it/s]\n"
+      "Download CPT's from BRO: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 9/9 [00:03<00:00,  2.86it/s]\n"
      ]
     }
    ],
@@ -1105,7 +1105,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1142,7 +1142,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1174,7 +1174,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1208,7 +1208,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1238,11 +1238,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "# Plot the variation of an attribute between group and single result for a single pile tip level\n",
-    "\n",
-    "multi_bearing_results.boxplot(attribute=\"k_v_1\", show_sqrt=True);"
-   ]
+   "source": "# Plot the variation of an attribute between group and single result for a single pile tip level\n\nmulti_bearing_results.boxplot(attribute=\"k_v_1\");"
   },
   {
    "cell_type": "markdown",
@@ -1370,7 +1366,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1400,7 +1396,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1425,7 +1421,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},
@@ -1494,7 +1490,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), …"
+       "VBox(children=(HBox(children=(Dropdown(description='Case:', options=('Default Case',), value='Default Case'), \u2026"
       ]
      },
      "metadata": {},

--- a/src/pypilecore/results/compression/multi_cpt_results.py
+++ b/src/pypilecore/results/compression/multi_cpt_results.py
@@ -596,13 +596,11 @@ class MultiCPTCompressionBearingResults:
 
         # validate attribute
         if attribute not in self.cpt_results.results[0].table.__dict__.keys():
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 {attribute} is not present in CPTResultsTable.
                 Please select one of the following attributes:
                 {list(self.cpt_results.results[0].table.__dict__.keys())}
-                """
-            )
+                """)
 
         # Create axes objects if not provided
         if axes is not None:

--- a/src/pypilecore/results/compression/multi_cpt_results.py
+++ b/src/pypilecore/results/compression/multi_cpt_results.py
@@ -561,7 +561,6 @@ class MultiCPTCompressionBearingResults:
         attribute: str,
         axes: Axes | None = None,
         figsize: Tuple[float, float] = (6.0, 6.0),
-        show_sqrt: bool = False,
         **kwargs: Any,
     ) -> Axes:
         """
@@ -579,15 +578,13 @@ class MultiCPTCompressionBearingResults:
         ----------
         attribute:
             result attribute to create boxplot. Please note that the attribute name must be present in
-            the `CPTResultsTable` and `CPTGroupResultsTable` class.
+            the `CPTResultsTable` class.
         axes:
             Optional `Axes` object where the boxplot data can be plotted on.
             If not provided, a new `plt.Figure` will be activated and the `Axes`
             object will be created and returned.
         figsize:
             Size of the activate figure, as the `plt.figure()` argument.
-        show_sqrt:
-            Add sqrt(2) bandwidth to figure
         **kwargs:
             All additional keyword arguments are passed to the `pyplot.subplots()` call.
 
@@ -598,18 +595,12 @@ class MultiCPTCompressionBearingResults:
         """
 
         # validate attribute
-        if (
-            attribute not in self.cpt_results.results[0].table.__dict__.keys()
-            or attribute not in self.group_results_table.__dict__.keys()
-        ):
+        if attribute not in self.cpt_results.results[0].table.__dict__.keys():
             raise ValueError(
                 f"""
-                {attribute} is not present in CPTResultsTable or CPTGroupResultsTable class.
-                Please select on of the following attributes:
-                {
-                    set(self.cpt_results.results[0].table.__dict__.keys())
-                    & set(self.group_results_table.__dict__.keys())
-                }
+                {attribute} is not present in CPTResultsTable.
+                Please select one of the following attributes:
+                {list(self.cpt_results.results[0].table.__dict__.keys())}
                 """
             )
 
@@ -658,37 +649,7 @@ class MultiCPTCompressionBearingResults:
             zorder=0,
         )
 
-        # ad additional bandwidth of sqrt(2) of the mean value
-        if show_sqrt:
-            axes.scatter(
-                np.flip(data.mean(axis=0)) * np.sqrt(2),
-                np.flip(
-                    np.arange(len(self.group_results_table.pile_tip_level_nap)) + 1
-                ),
-                marker="^",
-                color="tab:purple",
-                zorder=1,
-            )
-            axes.scatter(
-                np.flip(data.mean(axis=0)) / np.sqrt(2),
-                np.flip(
-                    np.arange(len(self.group_results_table.pile_tip_level_nap)) + 1
-                ),
-                marker="^",
-                color="tab:purple",
-                zorder=1,
-            )
-
-        # Draw group result over single result
-        axes.scatter(
-            np.flip(self.group_results_table.__getattribute__(attribute)),
-            np.flip(np.arange(len(self.group_results_table.pile_tip_level_nap)) + 1),
-            marker="o",
-            color="tab:red",
-            zorder=1,
-        )
-
-        # Draw group result over single result
+        # Draw mean annotation
         for i, x in enumerate(data.mean(axis=0)):
             axes.annotate(f"{x.round(2)}", xy=(x, i + 1))
 
@@ -701,8 +662,6 @@ class MultiCPTCompressionBearingResults:
                     "Single;Q25:Q75": "tab:blue",
                     "Single;Q50": "tab:orange",
                     "Single;mean": "tab:green",
-                    "Single;mean;sqrt": "tab:purple",
-                    "Group;normative": "tab:red",
                 }.items()
             ],
             loc="upper left",


### PR DESCRIPTION
Resolves #209 by removing the sqrt(2) bandwidth markers and the normative group result overlay from MultiCPTCompressionBearingResults.boxplot().

- Remove `show_sqrt` parameter and the sqrt(2) scatter block
- Remove the Group;normative scatter (red circles) overlay
- Update legend to only show the 4 standard boxplot traces
- Update attribute validation to only check CPTResultsTable (no longer needs to check CPTGroupResultsTable since the group attribute is unused)
- Update notebook to remove the now-removed `show_sqrt=True` argument

https://claude.ai/code/session_01AxdjbCNZ3YGheD3LkvxS5M