### PR TITLE
Add assertions for plot legend titles in bearing overview tests

### DIFF
--- a/tests/results/test_grouper.py
+++ b/tests/results/test_grouper.py
@@ -105,7 +105,12 @@ def test_grouper_results_max_bearing(
         assert mbr1.soil_properties.test_id == test_id
 
         assert isinstance(mbr1.plot_bearing_capacities(), plt.Axes)
-        assert isinstance(mbr1.plot_bearing_overview(), plt.Figure)
+        fig = mbr1.plot_bearing_overview()
+        assert isinstance(fig, plt.Figure)
+        bearing_legend = next(
+            ax.get_legend() for ax in fig.axes if ax.get_legend() is not None
+        )
+        assert bearing_legend.get_title().get_text() == f"name: {test_id}"
 
         plt.close("all")
 

--- a/tests/results/test_multi_cpt_results.py
+++ b/tests/results/test_multi_cpt_results.py
@@ -146,11 +146,17 @@ def test_multi_cpt_bearing_results(
             )
 
             assert isinstance(single_cpt_results.soil_properties, SoilProperties)
+            assert single_cpt_results.soil_properties.test_id == test_id
             assert isinstance(single_cpt_results.pile_head_level_nap, float)
             assert isinstance(single_cpt_results.table, CPTCompressionResultsTable)
             assert isinstance(single_cpt_results.plot_bearing_capacities(), Axes)
             plt.close("all")
-            assert isinstance(single_cpt_results.plot_bearing_overview(), Figure)
+            fig = single_cpt_results.plot_bearing_overview()
+            assert isinstance(fig, Figure)
+            bearing_legend = next(
+                ax.get_legend() for ax in fig.axes if ax.get_legend() is not None
+            )
+            assert bearing_legend.get_title().get_text() == f"name: {test_id}"
             plt.close("all")
 
             cpt_results_table = single_cpt_results.table

--- a/tests/results/test_multi_cpt_tension_results.py
+++ b/tests/results/test_multi_cpt_tension_results.py
@@ -91,11 +91,17 @@ def test_multi_cpt_bearing_results(
             )
 
             assert isinstance(single_cpt_results.soil_properties, SoilProperties)
+            assert single_cpt_results.soil_properties.test_id == test_id
             assert isinstance(single_cpt_results.pile_head_level_nap, float)
             assert isinstance(single_cpt_results.table, CPTTensionResultsTable)
             assert isinstance(single_cpt_results.plot_bearing_capacities(), Axes)
             plt.close("all")
-            assert isinstance(single_cpt_results.plot_bearing_overview(), Figure)
+            fig = single_cpt_results.plot_bearing_overview()
+            assert isinstance(fig, Figure)
+            bearing_legend = next(
+                ax.get_legend() for ax in fig.axes if ax.get_legend() is not None
+            )
+            assert bearing_legend.get_title().get_text() == f"name: {test_id}"
             plt.close("all")
 
             cpt_results_table = single_cpt_results.table


### PR DESCRIPTION
## Summary
Enhanced test coverage for bearing overview plot functionality by adding assertions that verify the legend title contains the expected test ID.

## Key Changes
- **test_multi_cpt_results.py**: Updated `test_multi_cpt_bearing_results` to extract the figure from `plot_bearing_overview()` and assert that the bearing legend title matches the expected format `"name: {test_id}"`
- **test_multi_cpt_tension_results.py**: Applied the same test enhancement to `test_multi_cpt_bearing_results` for tension results
- **test_grouper.py**: Updated `test_grouper_results_max_bearing` with identical legend title assertion logic
- **test_multi_cpt_results.py & test_multi_cpt_tension_results.py**: Added assertion to verify `soil_properties.test_id` matches the expected test ID

## Implementation Details
The tests now:
1. Capture the figure object returned by `plot_bearing_overview()` instead of just type-checking it
2. Iterate through figure axes to find the one with a legend
3. Assert that the legend title text equals `f"name: {test_id}"` to ensure proper labeling of bearing capacity plots
4. Verify soil properties contain the correct test ID reference

This improves test robustness by validating not just the plot structure, but also the correctness of the legend labeling which is important for plot readability and data traceability.

https://claude.ai/code/session_01RW9aBjmj37XkwsM2AmgAPH